### PR TITLE
Changing the links in the About Section of codeofconduct

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -67,6 +67,7 @@
 	<main class="page-content" aria-label="Content">
 		<div class="wrapper">
 			<article class="post">
+				<br>
 				<h1 class="page-heading" style="color: #ec3750;">Code of Conduct</h1>
 				<p style="text-align: center;">The required standards of conduct for the Hack Club community & events.</p>
 				<div class="post-content">
@@ -100,10 +101,10 @@
               ">
 							<h3 class="f-title f_600 t_color f_size_18">Hack Club ITER</h3>
 							<ul class="list-unstyled f_list" style="margin-left: 0">
-								<li> <a href="/#">Workshops</a> </li>
-								<li> <a href="/#">Projects</a> </li>
-								<li> <a href="iter.hackclub.com">Home</a> </li>
-								<li> <a href="#">Discord</a> </li>
+								<li> <a href="iter.hackclub.com/workshops">Workshops</a> </li>
+								<li> <a href="iter.hackclub.com/projects/">Projects</a> </li>
+								<li> <a href="https://iter.hackclub.com">Home</a> </li>
+								<li> <a href="iter.hackclub.com/discord.html">Discord</a> </li>
 							</ul>
 						</div>
 					</div>
@@ -130,7 +131,7 @@
 							<div class="f_social_icon">
 								<a href="https://www.instagram.com/hackclubiter/" class="fab fa-instagram"></a>
 								<a href="https://twitter.com/hackclubiter" class="fab fa-twitter"></a>
-								<a href="#" class="fab fa-discord"></a>
+								<a href="iter.hackclub.com/discord.html" class="fab fa-discord"></a>
 								<a href="https://github.com/hackclubiter" class="fab fa-github"></a>
 								<br>
 								<a href="https://www.linkedin.com/company/hackclubiter/" class="fab fa-linkedin"></a>


### PR DESCRIPTION
Redirecting the links where they should i.e : - 
        iter.hackclub.com/workshops - Workshops
	iter.hackclub.com/projects - Projects
        https://iter.hackclub.com - Home
	iter.hackclub.com/discord.html - Discord

Also added a line break before "Code Of Conduct".